### PR TITLE
chore: add confition on repository to prevent unrelated workflows from run

### DIFF
--- a/.github/workflows/build-and-preview-site.yml
+++ b/.github/workflows/build-and-preview-site.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
 jobs:
   trigger-site-preview:
+    if: github.repository == 'meshery/meshery'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/eslint-gh.yml
+++ b/.github/workflows/eslint-gh.yml
@@ -2,6 +2,7 @@ name: eslint-check
 on: [pull_request]
 jobs:
   eslint:
+    if: github.repository == 'meshery/meshery'
     name: runner / eslint
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/meshmap.yml
+++ b/.github/workflows/meshmap.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   MeshMapScreenshot:
+    if: github.repository == 'meshery/meshery'
     runs-on: ubuntu-latest
     outputs:
       resource_url: ${{ steps.test_result.outputs.resource_url }}


### PR DESCRIPTION
**Notes for Reviewers**

There are lot's of workflows, all of them are copied from main repository meshery. And none of them related. Probably we could delete all of them, but for now only add condition on repository so that they are not running.  


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
